### PR TITLE
ci: self-healing weekly autoupdate with Claude fallback

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Autoupdate
         id: autoupdate

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,7 +1,7 @@
 name: Autoupdate
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 6 * * 1"
   workflow_dispatch:
   workflow_call:
 concurrency:
@@ -10,43 +10,220 @@ concurrency:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
+  issues: write
+env:
+  AUTOUPDATE_BRANCH: chore/autoupdate-${{ github.run_id }}
 jobs:
   update:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      updated: ${{ steps.autoupdate.outputs.updated }}
-      version: ${{ steps.autoupdate.outputs.version }}
+    timeout-minutes: 30
     steps:
-      - name: Сheckout repo
-        id: checkout_repo
+      - name: Checkout repo
         uses: actions/checkout@v5
         with:
-          path: "tmp"
-          ref: "main"
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.email "slavianich@gmail.com"
+          git config user.name "Siarhei Dudko"
+
+      - name: Create autoupdate branch
+        run: |
+          git checkout -b "$AUTOUPDATE_BRANCH"
+          git push -u origin "$AUTOUPDATE_BRANCH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Autoupdate
         id: autoupdate
+        continue-on-error: true
         uses: siarheidudko/autoupdater@v6
         with:
           author-email: "slavianich@gmail.com"
           author-name: "Siarhei Dudko"
-          working-directory: ${{ github.workspace }}/tmp
+          working-directory: ${{ github.workspace }}
           ref: ${{ github.repository }}
-          branch: "main"
+          branch: ${{ env.AUTOUPDATE_BRANCH }}
           builds-and-checks: |
+            npm run lint
             npm run build
             npm test
           debug: "true"
           ignore-packages: |
             @types/node
-  deploy:
-    runs-on: ubuntu-latest
-    needs: update
-    if: needs.update.outputs.updated == 'true'
-    steps:
-      - name: Trigger Build and Deploy Workflow
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: build-and-deploy.yml
-          ref: main
-          inputs: '{ "tag": "${{ needs.update.outputs.version }}" }'
+            nyc
+
+      - name: Persist autoupdater work on failure
+        if: steps.autoupdate.outcome == 'failure'
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "chore(deps): autoupdater partial update"
+          fi
+          git push --force-with-lease origin "HEAD:$AUTOUPDATE_BRANCH" || true
+
+      - name: Fallback baseline update if branch still empty vs main
+        if: steps.autoupdate.outcome == 'failure'
+        run: |
+          git fetch origin main
+          if git diff --quiet origin/main; then
+            npx --yes npm-check-updates -u || true
+            npm install --no-audit --no-fund || true
+            if [ -n "$(git status --porcelain)" ]; then
+              git add -A
+              git commit -m "chore(deps): npm-check-updates baseline (autoupdater fallback)"
+              git push origin "HEAD:$AUTOUPDATE_BRANCH"
+            fi
+          fi
+
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create autoupdate --color "0e8a16" --description "Automated dependency update PRs" --force || true
+          gh label create needs-claude --color "d4c5f9" --description "Needs Claude GitHub App to fix" --force || true
+
+      - name: Check for diff vs main on remote branch
+        id: diff
+        if: always()
+        run: |
+          git fetch origin main "$AUTOUPDATE_BRANCH"
+          if git diff --quiet "origin/main" "origin/$AUTOUPDATE_BRANCH"; then
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read package version from branch
+        id: pkg
+        if: steps.diff.outputs.has_diff == 'true'
+        run: |
+          VERSION=$(git show "origin/$AUTOUPDATE_BRANCH:package.json" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).version))")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR (autoupdater succeeded)
+        id: pr_success
+        if: |
+          steps.autoupdate.outcome == 'success' &&
+          steps.autoupdate.outputs.updated == 'true' &&
+          steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(cat <<EOF
+          Automated dependency update.
+
+          - autoupdater outcome: success
+          - target version: v${{ steps.pkg.outputs.version }}
+
+          PR-checks must be green before merge.
+          EOF
+          )
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$AUTOUPDATE_BRANCH" \
+            --title "chore(deps): autoupdate v${{ steps.pkg.outputs.version }}" \
+            --body "$BODY")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR (autoupdater failed)
+        id: pr_failure
+        if: steps.autoupdate.outcome == 'failure' && steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY=$(cat <<EOF
+          The dependency autoupdater failed during \`builds-and-checks\`.
+
+          Run log: $RUN_URL
+
+          A Claude session is requested below to push fixes onto this branch
+          so the following commands all exit 0:
+
+              npm run lint
+              npm run build
+              npm test
+
+          Only adjust what's needed for compatibility with the updated
+          dependencies (types, renamed exports, breaking changes). Do not
+          modify product logic.
+
+          The "PR checks" workflow will re-run on each new commit to confirm
+          a green state before merge.
+          EOF
+          )
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$AUTOUPDATE_BRANCH" \
+            --title "chore(deps): autoupdate (needs claude fix)" \
+            --body "$BODY" \
+            --draft)
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger PR checks (GITHUB_TOKEN can't auto-trigger pull_request)
+        if: steps.pr_success.outputs.pr_url != '' || steps.pr_failure.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run pr-checks.yml --ref "$AUTOUPDATE_BRANCH" || true
+
+      - name: Mention @claude in a PR comment
+        if: steps.pr_failure.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr_failure.outputs.pr_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          COMMENT=$(cat <<EOF
+          @claude the dependency autoupdater failed on this branch
+          (run: $RUN_URL).
+
+          Push commits to this branch until ALL THREE of the following
+          exit with code 0 in your local working tree, observed via the
+          Bash tool — not inferred:
+
+              npm run lint
+              npm run build
+              npm test
+
+          Hard rules:
+          - Run those three commands yourself before every push. Do not
+            push if any of them is red.
+          - If \`npm install\` or \`npm ci\` is needed, run it first
+            with \`--no-audit --no-fund\` and confirm exit 0.
+          - Limit edits to compatibility shims (types, renamed exports,
+            breaking-change adjustments, eslint-config tweaks for new
+            rule defaults). Do NOT change product logic.
+          - Do NOT bump the package version.
+          - When all three are green, push and stop. CI's
+            \`PR checks\` workflow will re-verify on the PR.
+
+          See CLAUDE.md in the repo root for the full project conventions.
+          EOF
+          )
+          gh pr comment "$PR_URL" --body "$COMMENT"
+
+      - name: Add labels to PR
+        if: steps.pr_success.outputs.pr_url != '' || steps.pr_failure.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr_success.outputs.pr_url || steps.pr_failure.outputs.pr_url }}
+        run: |
+          if [ "${{ steps.pr_failure.outputs.pr_url }}" != "" ]; then
+            gh pr edit "$PR_URL" --add-label autoupdate --add-label needs-claude || true
+          else
+            gh pr edit "$PR_URL" --add-label autoupdate || true
+          fi
+
+      - name: Cleanup branch when nothing to ship
+        if: always() && steps.diff.outputs.has_diff != 'true'
+        run: |
+          git push origin --delete "$AUTOUPDATE_BRANCH" || true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.number }}"
+  cancel-in-progress: false
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "Edit,Write,MultiEdit,Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git fetch:*),Bash(git restore:*),Bash(git checkout:*),Bash(rm:*),Bash(mkdir:*),Bash(cat:*),Bash(ls:*)"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,80 @@
+name: PR checks
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      NODE_VERSION: 22
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run linter
+        run: npm run lint
+      - name: Run builder
+        run: npm run build
+      - name: Archiving dist directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ${{ github.workspace }}/dist
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+      - name: Unarchiving dist directory
+        uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: ${{ github.workspace }}/dist
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run test
+        run: npm run cov

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      NODE_VERSION: 22
+      NODE_VERSION: 24
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -50,7 +50,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5

--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -1,0 +1,59 @@
+name: Release on version bump
+on:
+  push:
+    branches:
+      - main
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
+  cancel-in-progress: false
+permissions:
+  contents: write
+  actions: write
+env:
+  RELEASE_WORKFLOW: build-and-deploy.yml
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect version bump
+        id: bump
+        run: |
+          CURRENT=$(node -e "console.log(require('./package.json').version)")
+          PREVIOUS=$(git show HEAD~1:package.json 2>/dev/null \
+            | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log(JSON.parse(s).version)}catch{console.log('')}})")
+          echo "current=$CURRENT"
+          echo "previous=$PREVIOUS"
+          if [ -n "$CURRENT" ] && [ "$CURRENT" != "$PREVIOUS" ]; then
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "tag=v$CURRENT" >> "$GITHUB_OUTPUT"
+          else
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          git config user.email "slavianich@gmail.com"
+          git config user.name "Siarhei Dudko"
+
+      - name: Force-recreate tag on main HEAD
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          # autoupdater may have created this tag earlier on the autoupdate branch;
+          # we want it pinned to the merge commit on main so the release reflects what shipped.
+          git tag -fa "${{ steps.bump.outputs.tag }}" -m "Release ${{ steps.bump.outputs.tag }}"
+          git push --force origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Dispatch release workflow
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "$RELEASE_WORKFLOW" --ref main -f tag="${{ steps.bump.outputs.tag }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,4 +50,4 @@ If `npm install` is needed (e.g. lockfile changed), run it with `--no-audit --no
 ## CI quirks specific to this repo
 
 - `TOKEN_FOR_WORKFLOW` (PAT) is **not** configured. The autoupdate workflow uses `GITHUB_TOKEN` and explicitly dispatches `pr-checks.yml` after PR creation, because events created via `GITHUB_TOKEN` do not trigger downstream workflows. If you change autoupdate.yml, preserve this dispatch step.
-- The release pipeline (`build-and-deploy.yml`) runs on its own triggers; the new autoupdate flow does not invoke it directly — release is gated on PR merge to `main`.
+- Releases are wired via `release-on-version-bump.yml` (push to main → detect `package.json` version change → force-recreate `vX.Y.Z` tag on main HEAD → dispatch `build-and-deploy.yml`). Do not break this chain when editing CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ A stream-based JSON parser/stringifier. Published to npm as `@sergdudko/objectst
 ## Stack
 
 - TypeScript (`tsc`), targeting CJS + ESM dual build with type declarations.
-- Node `>=16` runtime; CI tests on Node 20 and 22.
+- Node `>=16` runtime; CI tests on Node 20, 22 and 24.
 - ESLint + Prettier.
 - Test runner: `node --test` with `tsx` import (no Jest/Mocha).
 
@@ -16,7 +16,7 @@ npm run lint          # ESLint over src/**/*.ts — must exit 0
 npm run build         # Clean + tsc CJS + tsc ESM + tsc types + write package.json shim
                       # (prebuild also runs lint)
 npm test              # node --test --import tsx test/**/*.test.ts — primary suite used by autoupdate
-npm run cov           # nyc-wrapped npm test; used by PR checks on Node 20/22
+npm run cov           # nyc-wrapped npm test; used by PR checks on Node 20/22/24
 ```
 
 ## Definition of "done" for any change you make

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# objectstream — instructions for Claude
+
+A stream-based JSON parser/stringifier. Published to npm as `@sergdudko/objectstream`.
+
+## Stack
+
+- TypeScript (`tsc`), targeting CJS + ESM dual build with type declarations.
+- Node `>=16` runtime; CI tests on Node 20 and 22.
+- ESLint + Prettier.
+- Test runner: `node --test` with `tsx` import (no Jest/Mocha).
+
+## Commands you must know
+
+```bash
+npm run lint          # ESLint over src/**/*.ts — must exit 0
+npm run build         # Clean + tsc CJS + tsc ESM + tsc types + write package.json shim
+                      # (prebuild also runs lint)
+npm test              # node --test --import tsx test/**/*.test.ts — primary suite used by autoupdate
+npm run cov           # nyc-wrapped npm test; used by PR checks on Node 20/22
+```
+
+## Definition of "done" for any change you make
+
+You are NOT done with a code change until **all three** of the following exit 0 in the working tree on the branch you're going to push:
+
+```bash
+npm run lint
+npm run build
+npm test
+```
+
+Run these explicitly with the `Bash` tool before your last commit on the branch. Do not assume "the change looks right" is sufficient — `tsc` errors and ESLint errors must be observed as exit code 0, not inferred. If any of them fail, fix the failure and re-run all three from a clean state until they all pass. Only then commit and push.
+
+If `npm install` is needed (e.g. lockfile changed), run it with `--no-audit --no-fund` and ensure it returned 0 before running checks.
+
+## Boundaries
+
+- Do not modify product logic when fixing dependency-compatibility issues. Acceptable edits: type adjustments, renamed exports, breaking-change shims, ESLint-config tweaks for new rule defaults.
+- Do not bump the package `version` manually. Versioning is handled by the autoupdate flow / maintainer on release.
+- Do not edit `.github/workflows/build-and-deploy.yml` unless explicitly asked — it is the release pipeline.
+- Do not push to `main` directly. Always work on the existing branch you were summoned to.
+
+## When you are working on an autoupdate PR
+
+- Branch will be `chore/autoupdate-<run_id>`.
+- Goal: bring `npm run lint && npm run build && npm test` to green.
+- Push compatibility fixes onto this branch. Each push re-runs `pr-checks.yml` automatically; you don't need to mention checks back to the maintainer until they're green.
+- If a fix is impossible without changing product behavior, stop and leave a comment explaining what's blocked rather than guessing.
+
+## CI quirks specific to this repo
+
+- `TOKEN_FOR_WORKFLOW` (PAT) is **not** configured. The autoupdate workflow uses `GITHUB_TOKEN` and explicitly dispatches `pr-checks.yml` after PR creation, because events created via `GITHUB_TOKEN` do not trigger downstream workflows. If you change autoupdate.yml, preserve this dispatch step.
+- The release pipeline (`build-and-deploy.yml`) runs on its own triggers; the new autoupdate flow does not invoke it directly — release is gated on PR merge to `main`.


### PR DESCRIPTION
## Summary

Replicates the self-healing weekly autoupdate flow already running on `dudko-dev/protoobject`. When the dependency autoupdater fails its `builds-and-checks` (e.g. major bump breaks the build), the workflow opens a draft PR and pings `@claude` to push compatibility fixes onto the branch.

### Files

- **`.github/workflows/autoupdate.yml`** — replaces existing daily push-to-main flow. Now weekly (Mon 06:00 UTC) + manual dispatch. Operates on a `chore/autoupdate-<run_id>` branch and goes through PR review.
- **`.github/workflows/pr-checks.yml`** — new. Runs `lint` + `build` (Node 22) and `cov` on Node 20/22 for every PR. Also exposes `workflow_dispatch` so the autoupdate flow can trigger it.
- **`.github/workflows/claude.yml`** — new. Runs `anthropics/claude-code-action@v1` on `@claude` mentions, with extended `--allowedTools` so Claude can actually `Edit`/`Write`/run `npm`.
- **`CLAUDE.md`** — new. Strict definition-of-done that future Claude sessions read in this repo.

### Deviations from the protoobject template (intentional)

1. **No `TOKEN_FOR_WORKFLOW` PAT.** This repo doesn't have one. Workflow uses `GITHUB_TOKEN` throughout. Since events created by `GITHUB_TOKEN` do **not** trigger downstream workflows, the workflow explicitly calls `gh workflow run pr-checks.yml --ref <branch>` after PR creation (workflow_dispatch is one of the exceptions). Subsequent commits from `claude[bot]` trigger PR checks normally via `pull_request: synchronize`.
2. **No `deploy` job.** The previous `autoupdate.yml` directly invoked `build-and-deploy.yml` via `benc-uk/workflow-dispatch@v1` after a successful update. The new flow assumes the release pipeline runs on PR merge to `main` (or on tag). **If `build-and-deploy.yml` only triggers on `workflow_dispatch`, releases will stop happening automatically — flag this before merge.**
3. **`builds-and-checks`** uses `npm run lint` + `npm run build` + `npm test` (no `test:ts` here).

### Prereqs (please verify before merge)

- [ ] Claude GitHub App installed on the repo
- [ ] Secret `CLAUDE_CODE_OAUTH_TOKEN` present
- [ ] `build-and-deploy.yml` triggers on push-to-main / tag (not only on workflow_dispatch from old autoupdate)

### Test plan

- [ ] PR-checks workflow comes up green on this PR (it should — only workflow files are added/modified; lint/build/test should pass on current source).
- [ ] After merge: Actions → Autoupdate → Run workflow. Verify a `chore/autoupdate-<run_id>` branch + PR appears, and that `pr-checks.yml` is dispatched against it (visible in Actions → PR checks).
- [ ] If autoupdater fails: a draft PR with labels `autoupdate, needs-claude` opens and a Claude run starts within ~1 min in Actions → Claude. Confirm Claude pushes a compatibility fix and PR checks go green afterwards.

Pilot for skill `autoupdate-with-claude` rollout across 7 repos. After this one is fully verified end-to-end, the same pattern goes to redux-cluster, redux-cluster-ws, stripe-js, ireceipt-pro/js, plus special-cased firebase-admin-cli and dudko-dev/agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZFzpa3MNzjh4kXkF3oLWV)_