### PR TITLE
ci: downgrade checkout/setup-node/download-artifact to v4 (node24 missing in runner externals)

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
           git push -u origin "$AUTOUPDATE_BRANCH"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,9 +26,9 @@ jobs:
       NODE_VERSION: 24
     steps:
       - name: Сheckout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache node modules
@@ -60,14 +60,14 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - name: Сheckout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Unarchiving dist directory
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: ${{ github.workspace }}/dist
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
@@ -93,14 +93,14 @@ jobs:
       NODE_VERSION: 24
     steps:
       - name: Сheckout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Unarchiving dist directory
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: ${{ github.workspace }}/dist
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache node modules
@@ -136,7 +136,7 @@ jobs:
           prerelease: ${{ !!endsWith(env.RELEASE_VERSION, '-beta') }}
       - name: Set registry npm packages
         if: ${{ !endsWith(env.RELEASE_VERSION, '-beta') }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           registry-url: "https://registry.npmjs.org"
       - name: Update npm to latest version

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
           fetch-depth: 1

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,9 +17,9 @@ jobs:
       NODE_VERSION: 24
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache node modules
@@ -53,14 +53,14 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Unarchiving dist directory
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: ${{ github.workspace }}/dist
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules

--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Recent autoupdate runs (and any other workflow using these actions) end with:

```
##[error]An error occurred trying to start process
'/home/runner/actions-runner/extracted/externals/node24/bin/node'
... No such file or directory
```

The error fires twice in post-job cleanup (Post Setup Node + Post Checkout repo). Functionally everything succeeds — branch created, PR opened, dispatched workflows fire — but the cleanup error marks the whole job red.

## Root cause

The runner image currently lacks `externals/node24`. Actions whose runtime is Node 24 (`actions/checkout@v5`, `actions/setup-node@v6`, `actions/download-artifact@v5`) try to run their post-cleanup script with a Node binary that doesn't exist, and fail.

This is grabli #5/#10 from the `autoupdate-with-claude` skill, in mirror form. Earlier the runner was missing `externals/node20` and the recommendation was to bump to v6 (node24-runtime). Now node24 is missing and v4 (node20-runtime) is the right choice.

## Fix

Downgrade across all 5 workflows to the v4 line:

- `actions/checkout@v5` → `@v4`
- `actions/setup-node@v6` → `@v4`
- `actions/download-artifact@v5` → `@v4`

The Node version we install for actual `run:` steps is independent of the action runtime — keeping `node-version: 24` (default) and matrix `[20, 22, 24]`.

## Test plan

- [ ] PR-checks green on this PR.
- [ ] After merge: re-run Autoupdate manually. Expect a clean green run (no Post-cleanup errors), branch creation/cleanup as before.

This downgrade is also being applied to `dudko-dev/protoobject` (separate PR) and will be the baseline for the rollout to remaining repos.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZFzpa3MNzjh4kXkF3oLWV)_