### PR TITLE
ci(claude): allow_bots: "*" so autoupdate can dispatch claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,6 +85,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "*"
           prompt: ${{ steps.prep.outputs.prompt }}
           claude_args: |
             --allowedTools "Edit,Write,MultiEdit,Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git fetch:*),Bash(git restore:*),Bash(git checkout:*),Bash(rm:*),Bash(mkdir:*),Bash(cat:*),Bash(ls:*)"


### PR DESCRIPTION
Fixes the next blocker after the GITHUB_TOKEN dispatch chain: when `autoupdate.yml` calls `gh workflow run claude.yml` via `GITHUB_TOKEN`, the actor is `github-actions[bot]`. `anthropics/claude-code-action@v1` rejects bot actors by default with:

```
Action failed with error: Workflow initiated by non-human actor:
github-actions (type: Bot). Add bot to allowed_bots list or use '*'
to allow all bots.
```

Adding `allowed_bots: "*"` to the action invocation lets the dispatched run proceed. Safe — the only bot dispatching this workflow is the repo's own `GITHUB_TOKEN` from `autoupdate.yml`.

Same fix is being applied to all 7 sibling repos in the rollout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZFzpa3MNzjh4kXkF3oLWV)_