### PR TITLE
ci(claude): expand allowedTools (Bash(git:*) + common utils)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
           fetch-depth: 1
-
       - name: Prepare autoupdate-fix prompt
         if: github.event_name == 'workflow_dispatch'
         id: prep
@@ -80,7 +79,6 @@ jobs:
           EOF
             echo PROMPT_EOF
           } >> "$GITHUB_OUTPUT"
-
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
@@ -88,4 +86,4 @@ jobs:
           allowed_bots: "*"
           prompt: ${{ steps.prep.outputs.prompt }}
           claude_args: |
-            --allowedTools "Edit,Write,MultiEdit,Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git fetch:*),Bash(git restore:*),Bash(git checkout:*),Bash(rm:*),Bash(mkdir:*),Bash(cat:*),Bash(ls:*)"
+            --allowedTools "Edit,Write,MultiEdit,Bash(git:*),Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(rm:*),Bash(mkdir:*),Bash(cat:*),Bash(ls:*),Bash(echo:*),Bash(grep:*),Bash(find:*),Bash(sed:*),Bash(awk:*),Bash(head:*),Bash(tail:*),Bash(diff:*),Bash(mv:*),Bash(cp:*),Bash(touch:*)"


### PR DESCRIPTION
When dispatched on autoupdate failure, Claude was hitting allowlist denials (likely on `git push` since only specific subcommands like `git status/diff/log/fetch/restore/checkout` were whitelisted; `git push` direct call wasn't). Result: `permission_denials_count: 1` and zero commits pushed.

Switch to `Bash(git:*)` glob (covers all git subcommands) + add common file/text utils (`grep/find/sed/awk/head/tail/mv/cp/touch/echo/diff`) so Claude has what it needs for routine dep-compat fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZFzpa3MNzjh4kXkF3oLWV)_